### PR TITLE
Coorinate system branch

### DIFF
--- a/battleship/coordinatesystem.cpp
+++ b/battleship/coordinatesystem.cpp
@@ -12,12 +12,10 @@ CoordinateSystem::CoordinateSystem(QWidget *parent)
     target_pixmap = new QPixmap(this->width,this->length);
     target_pixmap->fill();
     paintAxis();
-
     initial_x = 0;
     initial_y = 0;
     final_x = 0;
     final_y = 0;
-
     mouse_pressed = false;
     fillPointsList();
 }
@@ -63,8 +61,8 @@ void CoordinateSystem::clearInvalidPossiblePoints()
 
 void CoordinateSystem::fillPointsList()
 {
-    for(int y=0; y<length; y+= length/space_to_next_line)
-        for(int x=0; x<width; x += width/space_to_next_line)
+    for(int y=0; y<=length; y+= length/space_to_next_line)
+        for(int x=0; x<=width; x += width/space_to_next_line)
         {
             points.push_back(QPoint(x, y));
         }
@@ -79,7 +77,7 @@ void CoordinateSystem::paintAxis()
     pen1.setWidth(2);
     pixmap_painter.setPen(pen2);
 
-    for(int i=0; i<width; i+= width/space_to_next_line)
+    for(int i=space_to_next_line; i<width; i+= width/space_to_next_line)
     {
         pixmap_painter.drawLine(i, 0, i, length);
         if(i == (width/space_to_next_line) * space_to_next_line/2)
@@ -90,7 +88,7 @@ void CoordinateSystem::paintAxis()
         }
     }
 
-    for(int i=0; i<length; i+= length/space_to_next_line)
+    for(int i=space_to_next_line; i<length; i+= length/space_to_next_line)
     {
         pixmap_painter.drawLine(0, i, length, i);
         if(i == (width/space_to_next_line) * space_to_next_line/2)
@@ -139,7 +137,7 @@ void CoordinateSystem::paintEvent(QPaintEvent *e)
     {
         QPainter pixmap_painter(target_pixmap);
         QPen pen(ships_color);
-        pen.setWidth(2);
+        pen.setWidth(3);
         pixmap_painter.setPen(pen);
         pixmap_painter.drawLine(initial_x, initial_y, final_x, final_y);
     }
@@ -154,7 +152,7 @@ void CoordinateSystem::mouseMoveEvent(QMouseEvent *event)
     {
         QPainter pixmap_painter(target_pixmap);
         QPen pen(bg_color);
-        pen.setWidth(2);
+        pen.setWidth(3);
         pixmap_painter.setPen(pen);
         pixmap_painter.drawLine(initial_x, initial_y, final_x, final_y);
         update();
@@ -186,3 +184,24 @@ void CoordinateSystem::mouseMoveEvent(QMouseEvent *event)
     paintAxis();
     paintShips();
 }
+
+void CoordinateSystem::clearField()
+{
+    if(!ships.empty())
+    {
+        qDebug() << Q_FUNC_INFO << "ships ist nicht leer";
+        QPainter pixmap_painter(target_pixmap);
+        QPen pen(bg_color);
+        pen.setWidth(3);
+        pixmap_painter.setPen(pen);
+
+        for(auto s : ships)
+        {
+            pixmap_painter.drawLine(s);
+        }
+    }
+    update();
+    paintAxis();
+    ships.clear();
+}
+

--- a/battleship/coordinatesystem.h
+++ b/battleship/coordinatesystem.h
@@ -18,6 +18,7 @@ public:
     // Aktualisieren des Koordinatensystems
     void paintAxis();
     void paintShips();
+    void clearField();
 
     // Events
     void mousePressEvent(QMouseEvent* event);
@@ -25,14 +26,8 @@ public:
     void paintEvent(QPaintEvent *e);
     void mouseMoveEvent(QMouseEvent *event);
 
-private:
-    // TODO: Namen verbessern
-    QWidget *parent;
-    //QPainter *pixmap_painter;
     std::vector<QLine> ships;
-    std::vector<QPoint> points; // Alle punkte des Koordinatensystems
-    std::vector<QPoint> possible_points; // Moegliche Punkte bei mouseReleaseEvent
-
+    QPixmap *target_pixmap;
     // Farben
     Qt::GlobalColor lines_color = Qt::gray;
     Qt::GlobalColor x_y_axis_color = Qt::black;
@@ -40,18 +35,31 @@ private:
     Qt::GlobalColor bg_color = Qt::white;
 
 
+private:
+    // TODO: Namen verbessern
+    QWidget *parent;
+    //QPainter *pixmap_painter;
+
+    std::vector<QPoint> points; // Alle punkte des Koordinatensystems
+    std::vector<QPoint> possible_points; // Moegliche Punkte bei mouseReleaseEvent
+
+
+
+
+
     // TODO: ein Wert statt width und length, da das Spielfeld immer ein Quadrat bleibt
-    int width = 450;
-    int length = 450;
-    int space_to_next_line = 10;
+    int width = 400;
+    int length = 400;
+    int space_to_next_line = 20;
     int ship_length = (length/space_to_next_line)*2;
     int initial_x = 0;
     int initial_y = 0;
     int final_x = 0;
     int final_y = 0;
 
-    QPixmap *target_pixmap;
+
     bool mouse_pressed = false;
+
 };
 
 #endif // COORDINATESYSTEM_H

--- a/battleship/player.cpp
+++ b/battleship/player.cpp
@@ -84,7 +84,7 @@ QString* Player::getStats()
     QString grade = QString::number(getGrade());
     QString wins = QString::number(getNumberWins());
 
-    QString str = QString("Verloren: ") + failures +  QString("\nGewonnen: ") + wins + QString("\nSpielanzahl: ") + games + QString("\nNiveau: ") + grade + "";
+    QString str = QString("Losses:\t\t") + failures +  QString("\nWins:\t\t") + wins + QString("\nGames:\t\t") + games + QString("\nLevel:\t\t") + grade;
     QString *stats = new QString(str);
     return stats;
 }

--- a/battleship/playerform.cpp
+++ b/battleship/playerform.cpp
@@ -34,7 +34,7 @@ void PlayerForm::createPlayerInputFieldsGroup()
     QLabel *nameLabel = new QLabel(tr("Name:"));
     nameLine = new QLineEdit;
 
-    QLabel *ageLabel = new QLabel(tr("Alter:"));
+    QLabel *ageLabel = new QLabel(tr("Age:"));
     ageLine = new QLineEdit;
 
     layout->addWidget(nameLabel);

--- a/battleship/setshipsform.cpp
+++ b/battleship/setshipsform.cpp
@@ -5,7 +5,7 @@
 #include <QString>
 
 SetShipsForm::SetShipsForm(Player *player)
-    :player(player), size(QSize(500, 700))
+    :player(player), size(QSize(450, 660))
 {
     createMenu();
     createPlayerInformationGroupBox();
@@ -20,29 +20,33 @@ SetShipsForm::SetShipsForm(Player *player)
     QVBoxLayout *mainLayout = new QVBoxLayout;
     mainLayout->setMenuBar(menuBar);
     mainLayout->addWidget(coordinateSystemGroupBox);
+    mainLayout->setStretch(0, 1);
     mainLayout->addWidget(playerInformationGroupBox);
     mainLayout->addWidget(buttonBox);
     setLayout(mainLayout);
 
     setWindowTitle(tr("Battleship 0.0.1"));
-    resize(size);
+    // TODO: scalable, vorerst feste Größe
+    //resize(size);
+    this->setFixedSize(size);
+
 }
 
 void SetShipsForm::createMenu()
 {
     menuBar = new QMenuBar;
     gameMenu = new QMenu(tr("&Game"), this);
-    deleteShips = gameMenu->addAction(tr("Delete Ships"));
+    deleteShipsAction = gameMenu->addAction(tr("Delete Ships"));
     exitAction = gameMenu->addAction(tr("E&xit"));
     menuBar->addMenu(gameMenu);
-    connect(exitAction, SIGNAL(triggered()), this, SLOT(accept()));
+    connect(exitAction, SIGNAL(triggered()), this, SLOT(reject()));
+    connect(deleteShipsAction, SIGNAL(triggered()), this, SLOT(deleteShips()));
 }
 
 void SetShipsForm::createPlayerInformationGroupBox()
 {
     playerInformationGroupBox = new QGroupBox(tr("Player"));
     QVBoxLayout *layout = new QVBoxLayout;
-
     QList<QString> listOfLastOponents = player->getLastOponents();
     QString lastOponentsNames;
     for(int i = 0; i < listOfLastOponents.count(); i++)
@@ -50,8 +54,7 @@ void SetShipsForm::createPlayerInformationGroupBox()
         lastOponentsNames += (i != listOfLastOponents.count()-1) ? listOfLastOponents.at(i) + QString(", ") : listOfLastOponents.at(i) + QString(". ");
     }
 
-    QString info = *player->getName() + "\n" + QString::number(player->getAge()) + "\n" + *player->getStats() + "\n" + lastOponentsNames;
-
+    QString info = "Name:\t\t" + *player->getName() + "\nAge:\t\t" + QString::number(player->getAge()) + "\n" + *player->getStats() + "\n" + lastOponentsNames;
     QLabel *playerInfoLabel = new QLabel(info);
     layout->addWidget(playerInfoLabel);
     playerInformationGroupBox->setLayout(layout);
@@ -73,4 +76,9 @@ void SetShipsForm::accept()
     close();
     GameForm *setShipsForm = new GameForm();
     setShipsForm->exec();
+}
+
+void SetShipsForm::deleteShips()
+{
+    field->clearField();
 }

--- a/battleship/setshipsform.h
+++ b/battleship/setshipsform.h
@@ -15,8 +15,12 @@ class QMenuBar;
 class QPushButton;
 class QTextEdit;
 
+
+
 class SetShipsForm : public QDialog
 {
+    Q_OBJECT
+
 public:
     // TODO: Player Klasse statt QString benutzen, falls die Klasse notwendig
     SetShipsForm(Player *player);
@@ -32,7 +36,7 @@ private:
     QMenuBar *menuBar;
     QMenu *gameMenu;
     QAction *exitAction;
-    QAction *deleteShips;
+    QAction *deleteShipsAction;
 
     QGroupBox *playerInformationGroupBox;
     QGroupBox *coordinateSystemGroupBox;
@@ -44,6 +48,10 @@ private:
     QLabel *nameLabel;
 
     const QSize size;
+
+private slots:
+
+    void deleteShips();
 };
 
 #endif // DIALOG_H


### PR DESCRIPTION
- die Größe des Feldes sowie die Größe des Fensters zum Schiffe Setzen wurde angepasst (TODO: scalable)
- Bugfixes in der CoordinateSystem GUI-Klasse
- clearField() Methode, die von einem "private Slot" der setShips-GUI benutzt wird (TODO: andere Lösung?)
- einheitliche Beschriftungen der Eingabefelder (Englisch)